### PR TITLE
Add save validation wrapper

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,18 @@ CadQueryWrapper is a lightweight wrapper around [CadQuery/cadquery](https://gith
 
 ```python
 from cadquerywrapper.validator import load_rules, validate
+from cadquerywrapper import enable_validation, attach_model
 
 rules = load_rules("cadquerywrapper/rules/bambu_printability_rules.json")
 model = {"minimum_wall_thickness_mm": 0.6}
 errors = validate(model, rules)
+
+# enable validation for CadQuery save functions
+enable_validation(rules)
+
+# attach printability parameters to an object
+wp = cadquery.Workplane().box(1, 1, 1)
+attach_model(wp, model)
+# exporting will raise ValidationError if parameters fail
+wp.export("out.stl")
 ```

--- a/cadquerywrapper/__init__.py
+++ b/cadquerywrapper/__init__.py
@@ -1,5 +1,6 @@
 """CadQueryWrapper package."""
 
 from .validator import load_rules, validate, ValidationError
+from .save_validator import enable_validation, attach_model
 
-__all__ = ["load_rules", "validate", "ValidationError"]
+__all__ = ["load_rules", "validate", "ValidationError", "enable_validation", "attach_model"]

--- a/cadquerywrapper/save_validator.py
+++ b/cadquerywrapper/save_validator.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Callable
+
+import cadquery as cq
+
+from .validator import validate, load_rules, ValidationError
+
+_rules: dict | None = None
+_patched: bool = False
+_originals: list[tuple[Any, str, Callable]] = []
+
+
+def _set_rules(rules: dict | str | Path) -> None:
+    global _rules
+    if isinstance(rules, (str, Path)):
+        _rules = load_rules(rules)
+    else:
+        _rules = rules
+
+
+def attach_model(obj: Any, model: dict) -> None:
+    """Attach printability model data to a CadQuery object."""
+    setattr(obj, "_printability_model", model)
+
+
+def _validate_obj(obj: Any) -> None:
+    if _rules is None:
+        return
+    model = getattr(obj, "_printability_model", None)
+    if model is None:
+        return
+    errors = validate(model, _rules)
+    if errors:
+        raise ValidationError("; ".join(errors))
+
+
+def _wrap_function(func: Callable) -> Callable:
+    def wrapper(obj, *args, **kwargs):
+        _validate_obj(obj)
+        return func(obj, *args, **kwargs)
+
+    return wrapper
+
+
+def enable_validation(rules: dict | str | Path) -> None:
+    """Patch CadQuery saving functions to perform printability validation."""
+
+    global _patched
+    if _patched:
+        _set_rules(rules)
+        return
+
+    _set_rules(rules)
+
+    to_patch = [
+        (cq.exporters, "export"),
+        (cq.cq, "export"),
+        (cq.Shape, "exportStl"),
+        (cq.Shape, "exportStep"),
+        (cq.Shape, "exportBin"),
+        (cq.Shape, "exportBrep"),
+        (cq.Assembly, "export"),
+        (cq.Assembly, "save"),
+    ]
+
+    for target, name in to_patch:
+        orig = getattr(target, name)
+        _originals.append((target, name, orig))
+        setattr(target, name, _wrap_function(orig))
+
+    _patched = True
+
+
+__all__ = ["enable_validation", "attach_model"]


### PR DESCRIPTION
## Summary
- add `save_validator` module that patches CadQuery save functions
- expose `enable_validation` and `attach_model` from the package
- document how to use save validation

## Testing
- `python -m pip check`
- `python -m compileall -q cadquerywrapper`


------
https://chatgpt.com/codex/tasks/task_e_687a6685d34c8329899d3fab617e4bfd