### PR TITLE
Refactor into object oriented design

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,19 +5,21 @@ CadQueryWrapper is a lightweight wrapper around [CadQuery/cadquery](https://gith
 ## Usage
 
 ```python
-from cadquerywrapper.validator import load_rules, validate
-from cadquerywrapper import enable_validation, attach_model
+from cadquerywrapper import Validator, SaveValidator
 
-rules = load_rules("cadquerywrapper/rules/bambu_printability_rules.json")
+# load rules and create a validator
+validator = Validator("cadquerywrapper/rules/bambu_printability_rules.json")
+
 model = {"minimum_wall_thickness_mm": 0.6}
-errors = validate(model, rules)
+errors = validator.validate(model)
 
 # enable validation for CadQuery save functions
-enable_validation(rules)
+save_validator = SaveValidator(validator)
+save_validator.enable()
 
 # attach printability parameters to an object
 wp = cadquery.Workplane().box(1, 1, 1)
-attach_model(wp, model)
+SaveValidator.attach_model(wp, model)
 # exporting will raise ValidationError if parameters fail
 wp.export("out.stl")
 ```

--- a/cadquerywrapper/__init__.py
+++ b/cadquerywrapper/__init__.py
@@ -1,6 +1,6 @@
 """CadQueryWrapper package."""
 
-from .validator import load_rules, validate, ValidationError
-from .save_validator import enable_validation, attach_model
+from .validator import ValidationError, Validator, load_rules, validate
+from .save_validator import SaveValidator
 
-__all__ = ["load_rules", "validate", "ValidationError", "enable_validation", "attach_model"]
+__all__ = ["Validator", "SaveValidator", "ValidationError", "load_rules", "validate"]

--- a/cadquerywrapper/save_validator.py
+++ b/cadquerywrapper/save_validator.py
@@ -5,72 +5,75 @@ from typing import Any, Callable
 
 import cadquery as cq
 
-from .validator import validate, load_rules, ValidationError
-
-_rules: dict | None = None
-_patched: bool = False
-_originals: list[tuple[Any, str, Callable]] = []
+from .validator import ValidationError, Validator
 
 
-def _set_rules(rules: dict | str | Path) -> None:
-    global _rules
-    if isinstance(rules, (str, Path)):
-        _rules = load_rules(rules)
-    else:
-        _rules = rules
+class SaveValidator:
+    """Patch CadQuery save functions to apply printability validation."""
 
+    def __init__(self, rules: dict | str | Path | Validator):
+        if isinstance(rules, Validator):
+            self.validator = rules
+        else:
+            self.validator = Validator(rules)
+        self._patched: bool = False
+        self._originals: list[tuple[Any, str, Callable]] = []
 
-def attach_model(obj: Any, model: dict) -> None:
-    """Attach printability model data to a CadQuery object."""
-    setattr(obj, "_printability_model", model)
+    @staticmethod
+    def attach_model(obj: Any, model: dict) -> None:
+        """Attach printability model data to a CadQuery object."""
 
+        setattr(obj, "_printability_model", model)
 
-def _validate_obj(obj: Any) -> None:
-    if _rules is None:
-        return
-    model = getattr(obj, "_printability_model", None)
-    if model is None:
-        return
-    errors = validate(model, _rules)
-    if errors:
-        raise ValidationError("; ".join(errors))
+    def _validate_obj(self, obj: Any) -> None:
+        model = getattr(obj, "_printability_model", None)
+        if model is None:
+            return
+        errors = self.validator.validate(model)
+        if errors:
+            raise ValidationError("; ".join(errors))
 
+    def _wrap_function(self, func: Callable) -> Callable:
+        def wrapper(obj, *args, **kwargs):
+            self._validate_obj(obj)
+            return func(obj, *args, **kwargs)
 
-def _wrap_function(func: Callable) -> Callable:
-    def wrapper(obj, *args, **kwargs):
-        _validate_obj(obj)
-        return func(obj, *args, **kwargs)
+        return wrapper
 
-    return wrapper
+    def enable(self) -> None:
+        """Patch CadQuery saving functions to perform validation."""
 
+        if self._patched:
+            return
 
-def enable_validation(rules: dict | str | Path) -> None:
-    """Patch CadQuery saving functions to perform printability validation."""
+        to_patch = [
+            (cq.exporters, "export"),
+            (cq.cq, "export"),
+            (cq.Shape, "exportStl"),
+            (cq.Shape, "exportStep"),
+            (cq.Shape, "exportBin"),
+            (cq.Shape, "exportBrep"),
+            (cq.Assembly, "export"),
+            (cq.Assembly, "save"),
+        ]
 
-    global _patched
-    if _patched:
-        _set_rules(rules)
-        return
+        for target, name in to_patch:
+            orig = getattr(target, name)
+            self._originals.append((target, name, orig))
+            setattr(target, name, self._wrap_function(orig))
 
-    _set_rules(rules)
+        self._patched = True
 
-    to_patch = [
-        (cq.exporters, "export"),
-        (cq.cq, "export"),
-        (cq.Shape, "exportStl"),
-        (cq.Shape, "exportStep"),
-        (cq.Shape, "exportBin"),
-        (cq.Shape, "exportBrep"),
-        (cq.Assembly, "export"),
-        (cq.Assembly, "save"),
-    ]
+    def disable(self) -> None:
+        """Restore original CadQuery saving functions."""
 
-    for target, name in to_patch:
-        orig = getattr(target, name)
-        _originals.append((target, name, orig))
-        setattr(target, name, _wrap_function(orig))
+        if not self._patched:
+            return
 
-    _patched = True
+        for target, name, orig in self._originals:
+            setattr(target, name, orig)
 
+        self._originals.clear()
+        self._patched = False
 
-__all__ = ["enable_validation", "attach_model"]
+__all__ = ["SaveValidator"]

--- a/cadquerywrapper/validator.py
+++ b/cadquerywrapper/validator.py
@@ -1,7 +1,11 @@
+"""Printability rules validation helpers."""
+
 import json
 from pathlib import Path
 
 class ValidationError(Exception):
+    """Raised when an object fails printability validation."""
+
     pass
 
 def load_rules(rules_path: str | Path) -> dict:
@@ -41,4 +45,25 @@ def validate(model: dict, rules: dict) -> list[str]:
             )
     return errors
 
-__all__ = ["ValidationError", "load_rules", "validate"]
+
+class Validator:
+    """Object oriented wrapper around :func:`validate`."""
+
+    def __init__(self, rules: dict | str | Path):
+        if isinstance(rules, (str, Path)):
+            self.rules = load_rules(rules)
+        else:
+            self.rules = rules
+
+    @classmethod
+    def from_file(cls, path: str | Path) -> "Validator":
+        """Create a :class:`Validator` from a rules JSON file."""
+
+        return cls(load_rules(path))
+
+    def validate(self, model: dict) -> list[str]:
+        """Validate ``model`` against the stored ``rules``."""
+
+        return validate(model, self.rules)
+
+__all__ = ["ValidationError", "load_rules", "validate", "Validator"]


### PR DESCRIPTION
## Summary
- introduce `Validator` class for holding printability rules
- introduce `SaveValidator` class and remove old global logic
- expose classes via package `__init__`
- update README usage example

## Testing
- `python -m py_compile cadquerywrapper/validator.py`
- `python -m py_compile cadquerywrapper/save_validator.py`
- `python - <<'PY'
from cadquerywrapper import Validator, SaveValidator
print('ok')
PY
`

------
https://chatgpt.com/codex/tasks/task_e_687a69c2429c8329873ce7e3d38b5555