### PR TITLE
Apply code style fixes

### DIFF
--- a/cadquerywrapper/__init__.py
+++ b/cadquerywrapper/__init__.py
@@ -3,4 +3,10 @@
 from .validator import ValidationError, Validator, load_rules, validate
 from .save_validator import SaveValidator
 
-__all__ = ["Validator", "SaveValidator", "ValidationError", "load_rules", "validate"]
+__all__ = [
+    "Validator",
+    "SaveValidator",
+    "ValidationError",
+    "load_rules",
+    "validate",
+]

--- a/cadquerywrapper/save_validator.py
+++ b/cadquerywrapper/save_validator.py
@@ -76,4 +76,5 @@ class SaveValidator:
         self._originals.clear()
         self._patched = False
 
+
 __all__ = ["SaveValidator"]

--- a/cadquerywrapper/validator.py
+++ b/cadquerywrapper/validator.py
@@ -3,15 +3,18 @@
 import json
 from pathlib import Path
 
+
 class ValidationError(Exception):
     """Raised when an object fails printability validation."""
 
     pass
 
+
 def load_rules(rules_path: str | Path) -> dict:
     path = Path(rules_path)
     with path.open() as f:
         return json.load(f)
+
 
 def validate(model: dict, rules: dict) -> list[str]:
     """Validate model parameters against printability rules.
@@ -40,9 +43,11 @@ def validate(model: dict, rules: dict) -> list[str]:
             # skip complex values like max_model_size_mm
             continue
         if model_value < value:
-            errors.append(
-                f"{key.replace('_', ' ').capitalize()} {model_value} is below minimum {value}"
+            msg = (
+                f"{key.replace('_', ' ').capitalize()} {model_value} "
+                f"is below minimum {value}"
             )
+            errors.append(msg)
     return errors
 
 
@@ -65,5 +70,6 @@ class Validator:
         """Validate ``model`` against the stored ``rules``."""
 
         return validate(model, self.rules)
+
 
 __all__ = ["ValidationError", "load_rules", "validate", "Validator"]


### PR DESCRIPTION
## Summary
- format Python sources using black
- shorten long lines for PEP8 compliance

## Testing
- `flake8 cadquerywrapper | head -n 20`
- `python -m compileall cadquerywrapper`

------
https://chatgpt.com/codex/tasks/task_e_687a75283490832985da98990b1214a8