### PR TITLE
Add exception raising in Validator

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,13 +5,16 @@ CadQueryWrapper is a lightweight wrapper around [CadQuery/cadquery](https://gith
 ## Usage
 
 ```python
-from cadquerywrapper import Validator, SaveValidator
+from cadquerywrapper import Validator, SaveValidator, ValidationError
 
 # load rules and create a validator
 validator = Validator("cadquerywrapper/rules/bambu_printability_rules.json")
 
 model = {"minimum_wall_thickness_mm": 0.6}
-errors = validator.validate(model)
+try:
+    validator.validate(model)
+except ValidationError as exc:
+    print("Model invalid:", exc)
 
 save_validator = SaveValidator(validator)
 

--- a/cadquerywrapper/save_validator.py
+++ b/cadquerywrapper/save_validator.py
@@ -27,9 +27,7 @@ class SaveValidator:
         model = getattr(obj, "_printability_model", None)
         if model is None:
             return
-        errors = self.validator.validate(model)
-        if errors:
-            raise ValidationError("; ".join(errors))
+        self.validator.validate(model)
 
     def export(self, obj: Any, *args: Any, **kwargs: Any) -> Any:
         """Validate ``obj`` and delegate to :func:`cadquery.exporters.export`."""

--- a/cadquerywrapper/validator.py
+++ b/cadquerywrapper/validator.py
@@ -52,7 +52,11 @@ def validate(model: dict, rules: dict) -> list[str]:
 
 
 class Validator:
-    """Object oriented wrapper around :func:`validate`."""
+    """Object oriented wrapper around :func:`validate`.
+
+    The ``validate`` method will raise :class:`ValidationError` if the provided
+    model data does not satisfy the stored rules.
+    """
 
     def __init__(self, rules: dict | str | Path):
         if isinstance(rules, (str, Path)):
@@ -66,10 +70,18 @@ class Validator:
 
         return cls(load_rules(path))
 
-    def validate(self, model: dict) -> list[str]:
-        """Validate ``model`` against the stored ``rules``."""
+    def validate(self, model: dict) -> None:
+        """Validate ``model`` against the stored ``rules``.
 
-        return validate(model, self.rules)
+        Raises
+        ------
+        ValidationError
+            If any of the model values are below the configured limits.
+        """
+
+        errors = validate(model, self.rules)
+        if errors:
+            raise ValidationError("; ".join(errors))
 
 
 __all__ = ["ValidationError", "load_rules", "validate", "Validator"]

--- a/tests/test_validator.py
+++ b/tests/test_validator.py
@@ -84,6 +84,12 @@ def test_validator_from_file():
     assert "minimum_wall_thickness_mm" in validator.rules["rules"]
 
 
+def test_validator_validate_raises():
+    validator = Validator({"rules": {"minimum_wall_thickness_mm": 0.8}})
+    with pytest.raises(ValidationError):
+        validator.validate({"minimum_wall_thickness_mm": 0.5})
+
+
 def test_save_validator_delegates_and_validates():
     sv = SaveValidator({"rules": {"minimum_wall_thickness_mm": 0.8}})
     obj = DummyShape()


### PR DESCRIPTION
## Summary
- raise `ValidationError` directly from `Validator.validate`
- update `SaveValidator` to call new behavior
- document the new usage in README
- add unit test for validator exceptions

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687a7acab004832988159cf66cef8a51