### PR TITLE
Add high level wrapper class

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,24 +5,21 @@ CadQueryWrapper is a lightweight wrapper around [CadQuery/cadquery](https://gith
 ## Usage
 
 ```python
-from cadquerywrapper import Validator, SaveValidator, ValidationError
+from cadquerywrapper import CadQueryWrapper, ValidationError
 
-# load rules and create a validator
-validator = Validator("cadquerywrapper/rules/bambu_printability_rules.json")
+# load rules and create a wrapper
+wrapper = CadQueryWrapper("cadquerywrapper/rules/bambu_printability_rules.json")
 
 model = {"minimum_wall_thickness_mm": 0.6}
 try:
-    validator.validate(model)
+    wrapper.validate(model)
 except ValidationError as exc:
     print("Model invalid:", exc)
 
-save_validator = SaveValidator(validator)
-
-# attach printability parameters to an object
 wp = cadquery.Workplane().box(1, 1, 1)
-SaveValidator.attach_model(wp, model)
+wrapper.attach_model(wp, model)
 # exporting will raise ValidationError if parameters fail
-save_validator.export_stl(wp, "out.stl")
+wrapper.export_stl(wp, "out.stl")
 ```
 
 ## Code Style

--- a/cadquerywrapper/__init__.py
+++ b/cadquerywrapper/__init__.py
@@ -2,6 +2,7 @@
 
 from .validator import ValidationError, Validator, load_rules, validate
 from .save_validator import SaveValidator
+from .project import CadQueryWrapper
 
 __all__ = [
     "Validator",
@@ -9,4 +10,5 @@ __all__ = [
     "ValidationError",
     "load_rules",
     "validate",
+    "CadQueryWrapper",
 ]

--- a/cadquerywrapper/project.py
+++ b/cadquerywrapper/project.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import cadquery as cq
+
+from .save_validator import SaveValidator
+from .validator import ValidationError, Validator
+
+
+class CadQueryWrapper:
+    """Main interface combining :class:`Validator` and :class:`SaveValidator`."""
+
+    def __init__(self, rules: dict | str | Path):
+        self.validator = Validator(rules)
+        self.saver = SaveValidator(self.validator)
+
+    @staticmethod
+    def attach_model(obj: Any, model: dict) -> None:
+        """Attach printability model data to ``obj``."""
+
+        SaveValidator.attach_model(obj, model)
+
+    def validate(self, model: dict) -> None:
+        """Validate ``model`` using the underlying :class:`Validator`."""
+
+        self.validator.validate(model)
+
+    def export(self, obj: Any, *args: Any, **kwargs: Any) -> Any:
+        """Delegate to :meth:`SaveValidator.export`."""
+
+        return self.saver.export(obj, *args, **kwargs)
+
+    def cq_export(self, obj: Any, *args: Any, **kwargs: Any) -> Any:
+        """Delegate to :meth:`SaveValidator.cq_export`."""
+
+        return self.saver.cq_export(obj, *args, **kwargs)
+
+    def export_stl(self, shape: cq.Shape, *args: Any, **kwargs: Any) -> None:
+        """Delegate to :meth:`SaveValidator.export_stl`."""
+
+        self.saver.export_stl(shape, *args, **kwargs)
+
+    def export_step(self, shape: cq.Shape, *args: Any, **kwargs: Any) -> None:
+        """Delegate to :meth:`SaveValidator.export_step`."""
+
+        self.saver.export_step(shape, *args, **kwargs)
+
+    def export_bin(self, shape: cq.Shape, *args: Any, **kwargs: Any) -> None:
+        """Delegate to :meth:`SaveValidator.export_bin`."""
+
+        self.saver.export_bin(shape, *args, **kwargs)
+
+    def export_brep(self, shape: cq.Shape, *args: Any, **kwargs: Any) -> None:
+        """Delegate to :meth:`SaveValidator.export_brep`."""
+
+        self.saver.export_brep(shape, *args, **kwargs)
+
+    def assembly_export(self, assembly: cq.Assembly, *args: Any, **kwargs: Any) -> None:
+        """Delegate to :meth:`SaveValidator.assembly_export`."""
+
+        self.saver.assembly_export(assembly, *args, **kwargs)
+
+    def assembly_save(self, assembly: cq.Assembly, *args: Any, **kwargs: Any) -> None:
+        """Delegate to :meth:`SaveValidator.assembly_save`."""
+
+        self.saver.assembly_save(assembly, *args, **kwargs)
+
+
+__all__ = ["CadQueryWrapper"]


### PR DESCRIPTION
## Summary
- add `CadQueryWrapper` class to compose `Validator` and `SaveValidator`
- update package exports and README usage example
- extend unit tests for new convenience class
- fix test imports by adjusting `sys.path`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687a7c9e90b88329bdc1256e6c95899c