### PR TITLE
Support max model size validation

### DIFF
--- a/cadquerywrapper/validator.py
+++ b/cadquerywrapper/validator.py
@@ -40,7 +40,14 @@ def validate(model: dict, rules: dict) -> list[str]:
         if model_value is None:
             continue
         if isinstance(value, dict):
-            # skip complex values like max_model_size_mm
+            if isinstance(model_value, dict) and key == "max_model_size_mm":
+                for axis, limit in value.items():
+                    axis_value = model_value.get(axis)
+                    if axis_value is None:
+                        continue
+                    if axis_value > limit:
+                        msg = f"Model size {axis} {axis_value} exceeds maximum {limit}"
+                        errors.append(msg)
             continue
         if model_value < value:
             msg = (


### PR DESCRIPTION
## Summary
- handle dict rule values in `validate`
- compute bounding boxes in `SaveValidator` for max size checks
- test for `max_model_size_mm` limits

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687aa7cb0a8c8329b045d1de43bf28c5