### PR TITLE
Add file format validation

### DIFF
--- a/cadquerywrapper/save_validator.py
+++ b/cadquerywrapper/save_validator.py
@@ -85,27 +85,52 @@ class SaveValidator:
         if tri_count > limit:
             raise ValidationError(f"Triangle count {tri_count} exceeds maximum {limit}")
 
+    def _validate_file_format(self, file_name: str | Path | None) -> None:
+        """Ensure ``file_name`` uses an allowed extension."""
+
+        if file_name is None:
+            return
+        rules = self.validator.rules.get("rules", {})
+        preferred = rules.get("preferred_file_format")
+        alternates = rules.get("alternate_file_formats", []) or []
+        allowed = []
+        if preferred:
+            allowed.append(str(preferred).lower().lstrip("."))
+        for alt in alternates:
+            if alt:
+                allowed.append(str(alt).lower().lstrip("."))
+        if not allowed:
+            return
+        ext = Path(file_name).suffix.lower().lstrip(".")
+        if ext and ext not in allowed:
+            raise ValidationError(f"File format {ext.upper()} is not supported")
+
     def export(self, obj: Any, *args: Any, **kwargs: Any) -> Any:
         """Validate ``obj`` and delegate to :func:`cadquery.exporters.export`."""
 
         self._validate_obj(obj)
+        file_name = args[0] if args else None
+        file_name = kwargs.get("fileName", kwargs.get("fname", file_name))
+        self._validate_file_format(file_name)
         return cq.exporters.export(obj, *args, **kwargs)
 
     def cq_export(self, obj: Any, *args: Any, **kwargs: Any) -> Any:
         """Validate ``obj`` and delegate to :func:`cadquery.export`."""
 
         self._validate_obj(obj)
+        file_name = args[0] if args else None
+        file_name = kwargs.get("fileName", kwargs.get("fname", file_name))
+        self._validate_file_format(file_name)
         return cq.export(obj, *args, **kwargs)
 
     def export_stl(self, shape: cq.Shape, *args: Any, **kwargs: Any) -> None:
         """Validate ``shape`` and call ``exportStl``."""
 
         self._validate_obj(shape)
-        shape.exportStl(*args, **kwargs)
-        file_name = None
-        if args:
-            file_name = args[0]
+        file_name = args[0] if args else None
         file_name = kwargs.get("fileName", file_name)
+        self._validate_file_format(file_name)
+        shape.exportStl(*args, **kwargs)
         if file_name is not None:
             self._check_triangle_count(file_name)
 
@@ -113,30 +138,45 @@ class SaveValidator:
         """Validate ``shape`` and call ``exportStep``."""
 
         self._validate_obj(shape)
+        file_name = args[0] if args else None
+        file_name = kwargs.get("fileName", file_name)
+        self._validate_file_format(file_name)
         shape.exportStep(*args, **kwargs)
 
     def export_bin(self, shape: cq.Shape, *args: Any, **kwargs: Any) -> None:
         """Validate ``shape`` and call ``exportBin``."""
 
         self._validate_obj(shape)
+        file_name = args[0] if args else None
+        file_name = kwargs.get("fileName", file_name)
+        self._validate_file_format(file_name)
         shape.exportBin(*args, **kwargs)
 
     def export_brep(self, shape: cq.Shape, *args: Any, **kwargs: Any) -> None:
         """Validate ``shape`` and call ``exportBrep``."""
 
         self._validate_obj(shape)
+        file_name = args[0] if args else None
+        file_name = kwargs.get("fileName", file_name)
+        self._validate_file_format(file_name)
         shape.exportBrep(*args, **kwargs)
 
     def assembly_export(self, assembly: cq.Assembly, *args: Any, **kwargs: Any) -> None:
         """Validate ``assembly`` and call ``Assembly.export``."""
 
         self._validate_obj(assembly)
+        file_name = args[0] if args else None
+        file_name = kwargs.get("fileName", file_name)
+        self._validate_file_format(file_name)
         assembly.export(*args, **kwargs)
 
     def assembly_save(self, assembly: cq.Assembly, *args: Any, **kwargs: Any) -> None:
         """Validate ``assembly`` and call ``Assembly.save``."""
 
         self._validate_obj(assembly)
+        file_name = args[0] if args else None
+        file_name = kwargs.get("fileName", file_name)
+        self._validate_file_format(file_name)
         assembly.save(*args, **kwargs)
 
 

--- a/tests/test_validator.py
+++ b/tests/test_validator.py
@@ -253,3 +253,29 @@ def test_save_validator_intersections():
     SaveValidator.attach_model(assembly, {})
     with pytest.raises(ValidationError):
         sv.assembly_save(assembly)
+
+
+def test_save_validator_disallowed_format():
+    rules = {
+        "rules": {
+            "preferred_file_format": "STL",
+            "alternate_file_formats": ["3MF", "OBJ"],
+        }
+    }
+    sv = SaveValidator(rules)
+    shape = DummyShape()
+    with pytest.raises(ValidationError):
+        sv.export_stl(shape, "out.step")
+
+
+def test_save_validator_disallowed_format_export():
+    rules = {
+        "rules": {
+            "preferred_file_format": "STL",
+            "alternate_file_formats": ["OBJ"],
+        }
+    }
+    sv = SaveValidator(rules)
+    obj = DummyShape()
+    with pytest.raises(ValidationError):
+        sv.export(obj, "model.step")


### PR DESCRIPTION
## Summary
- validate export file formats using `preferred_file_format` and `alternate_file_formats` rules
- raise `ValidationError` when saving unsupported formats
- test invalid file format handling

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687b2ded8a64832993f93b17f9df9a84