### PR TITLE
Add file logging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+# Ignore log files
+cadquerywrapper.log

--- a/cadquerywrapper/__init__.py
+++ b/cadquerywrapper/__init__.py
@@ -3,6 +3,7 @@
 from .validator import ValidationError, Validator, load_rules, validate
 from .save_validator import SaveValidator
 from .project import CadQueryWrapper
+from .logger import get_logger
 
 __all__ = [
     "Validator",
@@ -11,4 +12,5 @@ __all__ = [
     "load_rules",
     "validate",
     "CadQueryWrapper",
+    "get_logger",
 ]

--- a/cadquerywrapper/logger.py
+++ b/cadquerywrapper/logger.py
@@ -1,0 +1,20 @@
+import logging
+from pathlib import Path
+
+_LOG_PATH = Path("cadquerywrapper.log")
+
+# Create logger for the package
+logger = logging.getLogger("cadquerywrapper")
+if not logger.handlers:
+    handler = logging.FileHandler(_LOG_PATH)
+    formatter = logging.Formatter(
+        "%(asctime)s - %(levelname)s - %(name)s - %(message)s"
+    )
+    handler.setFormatter(formatter)
+    logger.addHandler(handler)
+    logger.setLevel(logging.DEBUG)
+
+
+def get_logger(name: str | None = None) -> logging.Logger:
+    """Return a logger writing to ``cadquerywrapper.log``."""
+    return logger if name is None else logger.getChild(name)

--- a/cadquerywrapper/project.py
+++ b/cadquerywrapper/project.py
@@ -3,6 +3,10 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Any
 
+from .logger import get_logger
+
+logger = get_logger(__name__)
+
 import cadquery as cq
 
 from .save_validator import SaveValidator
@@ -13,58 +17,61 @@ class CadQueryWrapper:
     """Main interface combining :class:`Validator` and :class:`SaveValidator`."""
 
     def __init__(self, rules: dict | str | Path):
+        logger.debug("Initializing CadQueryWrapper with rules %s", rules)
         self.validator = Validator(rules)
         self.saver = SaveValidator(self.validator)
 
     @staticmethod
     def attach_model(obj: Any, model: dict) -> None:
         """Attach printability model data to ``obj``."""
-
+        logger.debug("Attaching model %s to object %s", model, obj)
         SaveValidator.attach_model(obj, model)
 
     def validate(self, model: dict) -> None:
         """Validate ``model`` using the underlying :class:`Validator`."""
-
+        logger.debug("Validating model %s", model)
         self.validator.validate(model)
 
     def export(self, obj: Any, *args: Any, **kwargs: Any) -> Any:
         """Delegate to :meth:`SaveValidator.export`."""
-
+        logger.debug("Exporting %s", obj)
         return self.saver.export(obj, *args, **kwargs)
 
     def cq_export(self, obj: Any, *args: Any, **kwargs: Any) -> Any:
         """Delegate to :meth:`SaveValidator.cq_export`."""
-
+        logger.debug("cq_export %s", obj)
         return self.saver.cq_export(obj, *args, **kwargs)
 
     def export_stl(self, shape: cq.Shape, *args: Any, **kwargs: Any) -> None:
         """Delegate to :meth:`SaveValidator.export_stl`."""
-
+        logger.debug("export_stl %s", shape)
         self.saver.export_stl(shape, *args, **kwargs)
 
     def export_step(self, shape: cq.Shape, *args: Any, **kwargs: Any) -> None:
         """Delegate to :meth:`SaveValidator.export_step`."""
-
+        logger.debug("export_step %s", shape)
         self.saver.export_step(shape, *args, **kwargs)
 
     def export_bin(self, shape: cq.Shape, *args: Any, **kwargs: Any) -> None:
         """Delegate to :meth:`SaveValidator.export_bin`."""
-
+        logger.debug("export_bin %s", shape)
         self.saver.export_bin(shape, *args, **kwargs)
 
     def export_brep(self, shape: cq.Shape, *args: Any, **kwargs: Any) -> None:
         """Delegate to :meth:`SaveValidator.export_brep`."""
-
+        logger.debug("export_brep %s", shape)
         self.saver.export_brep(shape, *args, **kwargs)
 
     def assembly_export(self, assembly: cq.Assembly, *args: Any, **kwargs: Any) -> None:
         """Delegate to :meth:`SaveValidator.assembly_export`."""
 
+        logger.debug("assembly_export %s", assembly)
         self.saver.assembly_export(assembly, *args, **kwargs)
 
     def assembly_save(self, assembly: cq.Assembly, *args: Any, **kwargs: Any) -> None:
         """Delegate to :meth:`SaveValidator.assembly_save`."""
 
+        logger.debug("assembly_save %s", assembly)
         self.saver.assembly_save(assembly, *args, **kwargs)
 
 

--- a/cadquerywrapper/save_validator.py
+++ b/cadquerywrapper/save_validator.py
@@ -3,6 +3,10 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Any
 
+from .logger import get_logger
+
+logger = get_logger(__name__)
+
 import trimesh
 
 import cadquery as cq
@@ -22,19 +26,23 @@ class SaveValidator:
 
     def __init__(self, rules: dict | str | Path | Validator):
         if isinstance(rules, Validator):
+            logger.debug("Initializing SaveValidator with Validator instance")
             self.validator = rules
         else:
+            logger.debug("Initializing SaveValidator with rules: %s", rules)
             self.validator = Validator(rules)
 
     @staticmethod
     def attach_model(obj: Any, model: dict) -> None:
         """Attach printability model data to a CadQuery object."""
-
+        logger.debug("Attaching model %s to object %s", model, obj)
         setattr(obj, "_printability_model", model)
 
     def _validate_obj(self, obj: Any) -> None:
+        logger.debug("Validating object %s", obj)
         model = getattr(obj, "_printability_model", None)
         if model is None:
+            logger.debug("No model attached; skipping validation")
             return
 
         combined_model = dict(model)
@@ -58,19 +66,23 @@ class SaveValidator:
 
         errors = validate(combined_model, self.validator.rules)
         if errors:
+            logger.debug("Validation errors: %s", errors)
             raise ValidationError("; ".join(errors))
 
         rules = self.validator.rules.get("rules", {})
         if rules.get("manifold_geometry_required"):
             if not is_manifold(obj):
+                logger.debug("Non-manifold geometry detected")
                 raise ValidationError("Non-manifold geometry detected")
 
         if rules.get("no_open_edges"):
             if shape_has_open_edges(obj):
+                logger.debug("Object contains open edges")
                 raise ValidationError("Object contains open edges")
 
         if rules.get("no_intersecting_geometry"):
             if assembly_has_intersections(obj):
+                logger.debug("Intersecting geometry detected")
                 raise ValidationError("Intersecting geometry detected")
 
         min_clear = rules.get("minimum_clearance_between_parts_mm")
@@ -79,6 +91,7 @@ class SaveValidator:
 
             clearance = assembly_minimum_clearance(obj)
             if clearance is not None and clearance < min_clear:
+                logger.debug("Clearance %s below minimum %s", clearance, min_clear)
                 raise ValidationError(
                     f"Clearance {clearance} below minimum {min_clear}"
                 )
@@ -89,6 +102,9 @@ class SaveValidator:
 
             angle = shape_max_overhang_angle(obj)
             if angle is not None and angle > max_overhang:
+                logger.debug(
+                    "Overhang angle %s exceeds maximum %s", angle, max_overhang
+                )
                 raise ValidationError(
                     f"Overhang angle {angle} exceeds maximum {max_overhang}"
                 )
@@ -102,7 +118,9 @@ class SaveValidator:
 
         mesh = trimesh.load_mesh(file_name)
         tri_count = int(len(mesh.faces))
+        logger.debug("Triangle count for %s: %s", file_name, tri_count)
         if tri_count > limit:
+            logger.debug("Triangle count %s exceeds maximum %s", tri_count, limit)
             raise ValidationError(f"Triangle count {tri_count} exceeds maximum {limit}")
 
     def _validate_file_format(self, file_name: str | Path | None) -> None:
@@ -123,29 +141,32 @@ class SaveValidator:
             return
         ext = Path(file_name).suffix.lower().lstrip(".")
         if ext and ext not in allowed:
+            logger.debug("File format %s not allowed; allowed: %s", ext, allowed)
             raise ValidationError(f"File format {ext.upper()} is not supported")
 
     def export(self, obj: Any, *args: Any, **kwargs: Any) -> Any:
         """Validate ``obj`` and delegate to :func:`cadquery.exporters.export`."""
-
+        logger.debug("export called with %s", obj)
         self._validate_obj(obj)
         file_name = args[0] if args else None
         file_name = kwargs.get("fileName", kwargs.get("fname", file_name))
         self._validate_file_format(file_name)
+        logger.debug("Saving with exporters.export to %s", file_name)
         return cq.exporters.export(obj, *args, **kwargs)
 
     def cq_export(self, obj: Any, *args: Any, **kwargs: Any) -> Any:
         """Validate ``obj`` and delegate to :func:`cadquery.export`."""
-
+        logger.debug("cq_export called with %s", obj)
         self._validate_obj(obj)
         file_name = args[0] if args else None
         file_name = kwargs.get("fileName", kwargs.get("fname", file_name))
         self._validate_file_format(file_name)
+        logger.debug("Saving with cq.export to %s", file_name)
         return cq.export(obj, *args, **kwargs)
 
     def export_stl(self, shape: cq.Shape, *args: Any, **kwargs: Any) -> None:
         """Validate ``shape`` and call ``exportStl``."""
-
+        logger.debug("export_stl called with %s", shape)
         self._validate_obj(shape)
         file_name = args[0] if args else None
         file_name = kwargs.get("fileName", file_name)
@@ -160,7 +181,7 @@ class SaveValidator:
 
     def export_step(self, shape: cq.Shape, *args: Any, **kwargs: Any) -> None:
         """Validate ``shape`` and call ``exportStep``."""
-
+        logger.debug("export_step called with %s", shape)
         self._validate_obj(shape)
         file_name = args[0] if args else None
         file_name = kwargs.get("fileName", file_name)
@@ -169,7 +190,7 @@ class SaveValidator:
 
     def export_bin(self, shape: cq.Shape, *args: Any, **kwargs: Any) -> None:
         """Validate ``shape`` and call ``exportBin``."""
-
+        logger.debug("export_bin called with %s", shape)
         self._validate_obj(shape)
         file_name = args[0] if args else None
         file_name = kwargs.get("fileName", file_name)
@@ -178,7 +199,7 @@ class SaveValidator:
 
     def export_brep(self, shape: cq.Shape, *args: Any, **kwargs: Any) -> None:
         """Validate ``shape`` and call ``exportBrep``."""
-
+        logger.debug("export_brep called with %s", shape)
         self._validate_obj(shape)
         file_name = args[0] if args else None
         file_name = kwargs.get("fileName", file_name)
@@ -187,7 +208,7 @@ class SaveValidator:
 
     def assembly_export(self, assembly: cq.Assembly, *args: Any, **kwargs: Any) -> None:
         """Validate ``assembly`` and call ``Assembly.export``."""
-
+        logger.debug("assembly_export called with %s", assembly)
         self._validate_obj(assembly)
         file_name = args[0] if args else None
         file_name = kwargs.get("fileName", file_name)
@@ -196,7 +217,7 @@ class SaveValidator:
 
     def assembly_save(self, assembly: cq.Assembly, *args: Any, **kwargs: Any) -> None:
         """Validate ``assembly`` and call ``Assembly.save``."""
-
+        logger.debug("assembly_save called with %s", assembly)
         self._validate_obj(assembly)
         file_name = args[0] if args else None
         file_name = kwargs.get("fileName", file_name)


### PR DESCRIPTION
## Summary
- provide logger helper writing to `cadquerywrapper.log`
- log loading rules and validations
- log SaveValidator operations
- log CadQueryWrapper usage
- gitignore log file

## Testing
- `black -q cadquerywrapper tests`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687b896ef9a88329b835d6c59f3bbc52