### PR TITLE
Add batch script for installing Python

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,19 @@ CadQueryWrapper is a lightweight wrapper around [CadQuery/cadquery](https://gith
 
 ## Installation
 
-Install the runtime dependencies with:
+If Python is not available on your system, run the helper script. Use the
+Bash version on Linux and macOS or the batch version on Windows:
+
+```bash
+./install_python.sh
+```
+
+```cmd
+install_python.bat
+```
+Both scripts are self-contained and do not require Python to run.
+
+Then install the runtime dependencies with:
 
 ```bash
 pip install -r requirements.txt

--- a/install_python.bat
+++ b/install_python.bat
@@ -1,0 +1,29 @@
+@echo off
+where python >NUL 2>NUL
+if %ERRORLEVEL%==0 (
+    echo Python is already installed.
+    exit /B 0
+)
+
+echo Python not found. Attempting installation...
+where choco >NUL 2>NUL
+if %ERRORLEVEL%==0 (
+    choco install -y python
+) else (
+    where winget >NUL 2>NUL
+    if %ERRORLEVEL%==0 (
+        winget install -e --id Python.Python.3
+    ) else (
+        echo No supported package manager found. Please install Python manually.
+        exit /B 1
+    )
+)
+
+where python >NUL 2>NUL
+if %ERRORLEVEL%==0 (
+    echo Python installed successfully.
+    exit /B 0
+) else (
+    echo Python installation failed. Please install manually.
+    exit /B 1
+)

--- a/install_python.sh
+++ b/install_python.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+set -e
+
+if command -v python3 >/dev/null 2>&1; then
+    echo "Python is already installed." && exit 0
+fi
+
+echo "Python not found. Attempting installation..."
+if command -v apt-get >/dev/null 2>&1; then
+    sudo apt-get update && sudo apt-get install -y python3 python3-pip
+elif command -v yum >/dev/null 2>&1; then
+    sudo yum install -y python3 python3-pip
+elif command -v brew >/dev/null 2>&1; then
+    brew install python
+else
+    echo "Unsupported package manager. Please install Python manually." >&2
+    exit 1
+fi
+
+if ! command -v python >/dev/null 2>&1 && command -v python3 >/dev/null 2>&1; then
+    sudo ln -s "$(command -v python3)" /usr/local/bin/python || true
+fi
+
+echo "Python installed successfully."


### PR DESCRIPTION
## Summary
- add `install_python.bat` for Windows users
- document both Bash and batch installer scripts

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687bda49f9cc8329a576e3df99e0decf