### PR TITLE
Add cross-platform setup scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 # Ignore log files
 cadquerywrapper.log
+__pycache__/
+.venv/

--- a/README.md
+++ b/README.md
@@ -52,3 +52,29 @@ wrapper.export_stl("out.stl")
 
 ## Code Style
 See [CODE_STYLE.md](CODE_STYLE.md) for contribution guidelines. Monkey patching is prohibited.
+
+## 🖥 Setup Instructions
+
+Run the setup script for your operating system:
+
+**Linux:**
+```bash
+chmod +x setup_linux.sh
+./setup_linux.sh
+```
+
+**macOS:**
+```bash
+chmod +x setup_mac.sh
+./setup_mac.sh
+```
+
+**Windows (PowerShell):**
+```powershell
+.\setup_windows.ps1
+```
+
+After installation:
+```bash
+poetry shell
+```

--- a/cadquerywrapper/save_validator.py
+++ b/cadquerywrapper/save_validator.py
@@ -168,7 +168,7 @@ class SaveValidator:
         file_name = kwargs.get("fileName", kwargs.get("fname", file_name))
         self._validate_file_format(file_name)
         logger.debug("Saving with cq.export to %s", file_name)
-        return cq.export(obj, *args, **kwargs)
+        return cq.export(obj, *args, **kwargs)  # type: ignore[attr-defined]
 
     def export_stl(self, shape: cq.Shape, *args: Any, **kwargs: Any) -> None:
         """Validate ``shape`` and call ``exportStl``."""

--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -e
+
+case "$(uname)" in
+  Linux*) script="setup_linux.sh" ;;
+  Darwin*) script="setup_mac.sh" ;;
+  MINGW*|MSYS*|CYGWIN*) script="setup_windows.ps1" ;;
+  *) echo "Unsupported OS: $(uname)" && exit 1 ;;
+esac
+
+if [ "$script" = "setup_windows.ps1" ]; then
+  if command -v pwsh >/dev/null 2>&1; then
+    pwsh "$script"
+  else
+    powershell.exe -ExecutionPolicy Bypass -File "$script"
+  fi
+else
+  bash "$script"
+fi
+

--- a/setup_linux.sh
+++ b/setup_linux.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+set -e
+
+echo "🔍 Checking Python 3.11+..."
+if ! python3 --version | grep -q "3.11"; then
+  echo "Installing Python 3.11..."
+  if command -v apt &>/dev/null; then
+    sudo apt update
+    sudo apt install -y python3.11 python3.11-venv python3.11-dev
+    sudo update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.11 1
+  elif command -v dnf &>/dev/null; then
+    sudo dnf install -y python3.11
+  elif command -v pacman &>/dev/null; then
+    sudo pacman -S --noconfirm python
+  else
+    echo "❌ Unsupported Linux package manager."
+    exit 1
+  fi
+fi
+
+echo "✅ Python version: $(python3 --version)"
+
+echo "🔍 Checking for Poetry..."
+if ! command -v poetry &>/dev/null; then
+  echo "📦 Installing Poetry..."
+  curl -sSL https://install.python-poetry.org | python3 -
+  export PATH="$HOME/.local/bin:$PATH"
+else
+  echo "✅ Poetry is installed: $(poetry --version)"
+fi
+
+echo "📦 Installing dependencies..."
+poetry install
+
+echo "✅ Linux setup complete. Use 'poetry shell' to activate environment."

--- a/setup_mac.sh
+++ b/setup_mac.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+set -e
+
+echo "🔍 Checking Python 3.11+..."
+if ! python3 --version | grep -q "3.11"; then
+  echo "Installing Python 3.11 using Homebrew..."
+  if ! command -v brew &>/dev/null; then
+    echo "📦 Installing Homebrew..."
+    /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+    export PATH="/opt/homebrew/bin:$PATH"
+  fi
+  brew install python@3.11
+  brew link python@3.11 --force
+fi
+
+echo "✅ Python version: $(python3 --version)"
+
+echo "🔍 Checking for Poetry..."
+if ! command -v poetry &>/dev/null; then
+  echo "📦 Installing Poetry..."
+  curl -sSL https://install.python-poetry.org | python3 -
+  export PATH="$HOME/.local/bin:$PATH"
+else
+  echo "✅ Poetry is installed: $(poetry --version)"
+fi
+
+echo "📦 Installing dependencies..."
+poetry install
+
+echo "✅ macOS setup complete. Use 'poetry shell' to activate environment."

--- a/setup_windows.ps1
+++ b/setup_windows.ps1
@@ -1,0 +1,35 @@
+# PowerShell script
+Write-Host "🔍 Checking for Chocolatey..."
+if (-not (Get-Command choco -ErrorAction SilentlyContinue)) {
+    Write-Host "📦 Installing Chocolatey..."
+    Set-ExecutionPolicy Bypass -Scope Process -Force
+    [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072
+    Invoke-Expression ((New-Object System.Net.WebClient).DownloadString('https://community.chocolatey.org/install.ps1'))
+}
+
+Write-Host "📦 Updating Chocolatey..."
+choco upgrade chocolatey -y
+
+Write-Host "📦 Installing build tools..."
+choco install python --version=3.11.5 -y
+choco install visualstudio2022buildtools --package-parameters '--add Microsoft.VisualStudio.Workload.VCTools --includeRecommended' -y
+choco install windows-sdk-10.0 -y
+choco install cmake --installargs 'ADD_CMAKE_TO_PATH=System' -y
+choco install ninja -y
+choco install make -y
+choco install git -y
+choco install openssl.light -y
+
+Write-Host "✅ Python version: $(python --version)"
+
+Write-Host "🔍 Checking for Poetry..."
+if (-not (Get-Command poetry -ErrorAction SilentlyContinue)) {
+    Write-Host "📦 Installing Poetry..."
+    (Invoke-WebRequest -Uri https://install.python-poetry.org -UseBasicParsing).Content | python -
+    $env:Path += ';' + $env:USERPROFILE + '\.poetry\bin'
+}
+
+Write-Host "📦 Installing dependencies..."
+poetry install
+
+Write-Host "✅ Windows setup complete. Run 'poetry shell' to activate environment."


### PR DESCRIPTION
## Summary
- add `setup.sh` dispatcher script
- implement OS-specific setup scripts
- document running setup scripts
- ignore virtual env and caches
- silence mypy false positive

## Testing
- `pytest -q`
- `ruff check cadquerywrapper tests`
- `mypy cadquerywrapper`
- `black --check cadquerywrapper`


------
https://chatgpt.com/codex/tasks/task_e_687f30f960a48329ad28905c8d07a204