### PR TITLE
Integrate cadquerywrapper into examples

### DIFF
--- a/examples/Ex001_Simple_Block.py
+++ b/examples/Ex001_Simple_Block.py
@@ -1,4 +1,5 @@
 import cadquery as cq
+from cadquerywrapper import CadQueryWrapper
 
 # These can be modified rather than hardcoding values for each dimension.
 length = 80.0  # Length of the block
@@ -17,3 +18,10 @@ result = cq.Workplane("XY").box(length, height, thickness)
 # show(result)  # Render the result of this script
 
 show_object(result)
+
+# Validate and export with CadQueryWrapper
+wrapper = CadQueryWrapper(
+    "cadquerywrapper/rules/bambu_printability_rules.json",
+    result,
+)
+wrapper.export_stl("Ex001_Simple_Block.stl")

--- a/examples/Ex002_Block_With_Bored_Center_Hole.py
+++ b/examples/Ex002_Block_With_Bored_Center_Hole.py
@@ -1,4 +1,5 @@
 import cadquery as cq
+from cadquerywrapper import CadQueryWrapper
 
 # These can be modified rather than hardcoding values for each dimension.
 length = 80.0  # Length of the block
@@ -23,3 +24,10 @@ result = (
 
 # Displays the result of this script
 show_object(result)
+
+# Validate and export with CadQueryWrapper
+wrapper = CadQueryWrapper(
+    "cadquerywrapper/rules/bambu_printability_rules.json",
+    result,
+)
+wrapper.export_stl("Ex002_Block_With_Bored_Center_Hole.stl")

--- a/examples/Ex003_Pillow_Block_With_Counterbored_Holes.py
+++ b/examples/Ex003_Pillow_Block_With_Counterbored_Holes.py
@@ -1,4 +1,5 @@
 import cadquery as cq
+from cadquerywrapper import CadQueryWrapper
 
 # These can be modified rather than hardcoding values for each dimension.
 length = 80.0  # Length of the block
@@ -42,3 +43,10 @@ result = (
 
 # Displays the result of this script
 show_object(result)
+
+# Validate and export with CadQueryWrapper
+wrapper = CadQueryWrapper(
+    "cadquerywrapper/rules/bambu_printability_rules.json",
+    result,
+)
+wrapper.export_stl("Ex003_Pillow_Block_With_Counterbored_Holes.stl")

--- a/examples/Ex004_Extruded_Cylindrical_Plate.py
+++ b/examples/Ex004_Extruded_Cylindrical_Plate.py
@@ -1,4 +1,5 @@
 import cadquery as cq
+from cadquerywrapper import CadQueryWrapper
 
 # These can be modified rather than hardcoding values for each dimension.
 circle_radius = 50.0  # Radius of the plate
@@ -30,3 +31,10 @@ result = (
 
 # Displays the result of this script
 show_object(result)
+
+# Validate and export with CadQueryWrapper
+wrapper = CadQueryWrapper(
+    "cadquerywrapper/rules/bambu_printability_rules.json",
+    result,
+)
+wrapper.export_stl("Ex004_Extruded_Cylindrical_Plate.stl")

--- a/examples/Ex005_Extruded_Lines_and_Arcs.py
+++ b/examples/Ex005_Extruded_Lines_and_Arcs.py
@@ -1,4 +1,5 @@
 import cadquery as cq
+from cadquerywrapper import CadQueryWrapper
 
 # These can be modified rather than hardcoding values for each dimension.
 width = 2.0  # Overall width of the plate
@@ -47,3 +48,10 @@ result = (
 
 # Displays the result of this script
 show_object(result)
+
+# Validate and export with CadQueryWrapper
+wrapper = CadQueryWrapper(
+    "cadquerywrapper/rules/bambu_printability_rules.json",
+    result,
+)
+wrapper.export_stl("Ex005_Extruded_Lines_and_Arcs.stl")

--- a/examples/Ex006_Moving_the_Current_Working_Point.py
+++ b/examples/Ex006_Moving_the_Current_Working_Point.py
@@ -1,4 +1,5 @@
 import cadquery as cq
+from cadquerywrapper import CadQueryWrapper
 
 # These can be modified rather than hardcoding values for each dimension.
 circle_radius = 3.0  # The outside radius of the plate
@@ -33,3 +34,10 @@ result = result.extrude(thickness)
 
 # Displays the result of this script
 show_object(result)
+
+# Validate and export with CadQueryWrapper
+wrapper = CadQueryWrapper(
+    "cadquerywrapper/rules/bambu_printability_rules.json",
+    result,
+)
+wrapper.export_stl("Ex006_Moving_the_Current_Working_Point.stl")

--- a/examples/Ex007_Using_Point_Lists.py
+++ b/examples/Ex007_Using_Point_Lists.py
@@ -1,4 +1,5 @@
 import cadquery as cq
+from cadquerywrapper import CadQueryWrapper
 
 # These can be modified rather than hardcoding values for each dimension.
 plate_radius = 2.0  # The radius of the plate that will be extruded
@@ -30,3 +31,10 @@ result = r.extrude(thickness)
 
 # Displays the result of this script
 show_object(result)
+
+# Validate and export with CadQueryWrapper
+wrapper = CadQueryWrapper(
+    "cadquerywrapper/rules/bambu_printability_rules.json",
+    result,
+)
+wrapper.export_stl("Ex007_Using_Point_Lists.stl")

--- a/examples/Ex008_Polygon_Creation.py
+++ b/examples/Ex008_Polygon_Creation.py
@@ -1,4 +1,5 @@
 import cadquery as cq
+from cadquerywrapper import CadQueryWrapper
 
 # These can be modified rather than hardcoding values for each dimension.
 width = 3.0  # The width of the plate
@@ -40,3 +41,10 @@ result = (
 
 # Displays the result of this script
 show_object(result)
+
+# Validate and export with CadQueryWrapper
+wrapper = CadQueryWrapper(
+    "cadquerywrapper/rules/bambu_printability_rules.json",
+    result,
+)
+wrapper.export_stl("Ex008_Polygon_Creation.stl")

--- a/examples/Ex009_Polylines.py
+++ b/examples/Ex009_Polylines.py
@@ -1,4 +1,5 @@
 import cadquery as cq
+from cadquerywrapper import CadQueryWrapper
 
 # These can be modified rather than hardcoding values for each dimension.
 # Define up our Length, Height, Width, and thickness of the beam
@@ -35,3 +36,10 @@ result = cq.Workplane("front").polyline(pts).mirrorY().extrude(L)
 
 # Displays the result of this script
 show_object(result)
+
+# Validate and export with CadQueryWrapper
+wrapper = CadQueryWrapper(
+    "cadquerywrapper/rules/bambu_printability_rules.json",
+    result,
+)
+wrapper.export_stl("Ex009_Polylines.stl")

--- a/examples/Ex010_Defining_an_Edge_with_a_Spline.py
+++ b/examples/Ex010_Defining_an_Edge_with_a_Spline.py
@@ -1,4 +1,5 @@
 import cadquery as cq
+from cadquerywrapper import CadQueryWrapper
 
 # 1.  Establishes a workplane to create the spline on to extrude.
 # 1a. Uses the X and Y origins to define the workplane, meaning that the
@@ -25,3 +26,10 @@ result = r.extrude(0.5)
 
 # Displays the result of this script
 show_object(result)
+
+# Validate and export with CadQueryWrapper
+wrapper = CadQueryWrapper(
+    "cadquerywrapper/rules/bambu_printability_rules.json",
+    result,
+)
+wrapper.export_stl("Ex010_Defining_an_Edge_with_a_Spline.stl")

--- a/examples/Ex011_Mirroring_Symmetric_Geometry.py
+++ b/examples/Ex011_Mirroring_Symmetric_Geometry.py
@@ -1,4 +1,5 @@
 import cadquery as cq
+from cadquerywrapper import CadQueryWrapper
 
 # 1.  Establishes a workplane that an object can be built on.
 # 1a. Uses the named plane orientation "front" to define the workplane, meaning
@@ -18,3 +19,10 @@ result = r.mirrorY().extrude(0.25)
 
 # Displays the result of this script
 show_object(result)
+
+# Validate and export with CadQueryWrapper
+wrapper = CadQueryWrapper(
+    "cadquerywrapper/rules/bambu_printability_rules.json",
+    result,
+)
+wrapper.export_stl("Ex011_Mirroring_Symmetric_Geometry.stl")

--- a/examples/Ex012_Creating_Workplanes_on_Faces.py
+++ b/examples/Ex012_Creating_Workplanes_on_Faces.py
@@ -1,4 +1,5 @@
 import cadquery as cq
+from cadquerywrapper import CadQueryWrapper
 
 # 1.  Establishes a workplane that an object can be built on.
 # 1a. Uses the named plane orientation "front" to define the workplane, meaning
@@ -14,3 +15,10 @@ result = result.faces(">Z").workplane().hole(0.5)
 
 # Displays the result of this script
 show_object(result)
+
+# Validate and export with CadQueryWrapper
+wrapper = CadQueryWrapper(
+    "cadquerywrapper/rules/bambu_printability_rules.json",
+    result,
+)
+wrapper.export_stl("Ex012_Creating_Workplanes_on_Faces.stl")

--- a/examples/Ex013_Locating_a_Workplane_on_a_Vertex.py
+++ b/examples/Ex013_Locating_a_Workplane_on_a_Vertex.py
@@ -1,4 +1,5 @@
 import cadquery as cq
+from cadquerywrapper import CadQueryWrapper
 
 # 1.  Establishes a workplane that an object can be built on.
 # 1a. Uses the named plane orientation "front" to define the workplane, meaning
@@ -19,3 +20,10 @@ result = result.circle(1.0).cutThruAll()
 
 # Displays the result of this script
 show_object(result)
+
+# Validate and export with CadQueryWrapper
+wrapper = CadQueryWrapper(
+    "cadquerywrapper/rules/bambu_printability_rules.json",
+    result,
+)
+wrapper.export_stl("Ex013_Locating_a_Workplane_on_a_Vertex.stl")

--- a/examples/Ex014_Offset_Workplanes.py
+++ b/examples/Ex014_Offset_Workplanes.py
@@ -1,4 +1,5 @@
 import cadquery as cq
+from cadquerywrapper import CadQueryWrapper
 
 # 1.  Establishes a workplane that an object can be built on.
 # 1a. Uses the named plane orientation "front" to define the workplane, meaning
@@ -18,3 +19,10 @@ result = result.circle(1.0).extrude(0.5)
 
 # Displays the result of this script
 show_object(result)
+
+# Validate and export with CadQueryWrapper
+wrapper = CadQueryWrapper(
+    "cadquerywrapper/rules/bambu_printability_rules.json",
+    result,
+)
+wrapper.export_stl("Ex014_Offset_Workplanes.stl")

--- a/examples/Ex015_Rotated_Workplanes.py
+++ b/examples/Ex015_Rotated_Workplanes.py
@@ -1,4 +1,5 @@
 import cadquery as cq
+from cadquerywrapper import CadQueryWrapper
 
 # 1.  Establishes a workplane that an object can be built on.
 # 1a. Uses the named plane orientation "front" to define the workplane, meaning
@@ -26,3 +27,10 @@ result = (
 
 # Displays the result of this script
 show_object(result)
+
+# Validate and export with CadQueryWrapper
+wrapper = CadQueryWrapper(
+    "cadquerywrapper/rules/bambu_printability_rules.json",
+    result,
+)
+wrapper.export_stl("Ex015_Rotated_Workplanes.stl")

--- a/examples/Ex016_Using_Construction_Geometry.py
+++ b/examples/Ex016_Using_Construction_Geometry.py
@@ -1,4 +1,5 @@
 import cadquery as cq
+from cadquerywrapper import CadQueryWrapper
 
 # Create a block with holes in each corner of a rectangle on that workplane.
 # 1.  Establishes a workplane that an object can be built on.
@@ -24,3 +25,10 @@ result = (
 
 # Displays the result of this script
 show_object(result)
+
+# Validate and export with CadQueryWrapper
+wrapper = CadQueryWrapper(
+    "cadquerywrapper/rules/bambu_printability_rules.json",
+    result,
+)
+wrapper.export_stl("Ex016_Using_Construction_Geometry.stl")

--- a/examples/Ex017_Shelling_to_Create_Thin_Features.py
+++ b/examples/Ex017_Shelling_to_Create_Thin_Features.py
@@ -1,4 +1,5 @@
 import cadquery as cq
+from cadquerywrapper import CadQueryWrapper
 
 # Create a hollow box that's open on both ends with a thin wall.
 # 1.  Establishes a workplane that an object can be built on.
@@ -12,3 +13,10 @@ result = cq.Workplane("front").box(2, 2, 2).faces("+Z").shell(0.05)
 
 # Displays the result of this script
 show_object(result)
+
+# Validate and export with CadQueryWrapper
+wrapper = CadQueryWrapper(
+    "cadquerywrapper/rules/bambu_printability_rules.json",
+    result,
+)
+wrapper.export_stl("Ex017_Shelling_to_Create_Thin_Features.stl")

--- a/examples/Ex018_Making_Lofts.py
+++ b/examples/Ex018_Making_Lofts.py
@@ -1,4 +1,5 @@
 import cadquery as cq
+from cadquerywrapper import CadQueryWrapper
 
 # Create a lofted section between a rectangle and a circular section.
 # 1.  Establishes a workplane that an object can be built on.
@@ -23,3 +24,10 @@ result = (
 
 # Displays the result of this script
 show_object(result)
+
+# Validate and export with CadQueryWrapper
+wrapper = CadQueryWrapper(
+    "cadquerywrapper/rules/bambu_printability_rules.json",
+    result,
+)
+wrapper.export_stl("Ex018_Making_Lofts.stl")

--- a/examples/Ex019_Counter_Sunk_Holes.py
+++ b/examples/Ex019_Counter_Sunk_Holes.py
@@ -1,4 +1,5 @@
 import cadquery as cq
+from cadquerywrapper import CadQueryWrapper
 
 # Create a plate with 4 counter-sunk holes in it.
 # 1.  Establishes a workplane using an XY object instead of a named plane.
@@ -23,3 +24,10 @@ result = (
 
 # Displays the result of this script
 show_object(result)
+
+# Validate and export with CadQueryWrapper
+wrapper = CadQueryWrapper(
+    "cadquerywrapper/rules/bambu_printability_rules.json",
+    result,
+)
+wrapper.export_stl("Ex019_Counter_Sunk_Holes.stl")

--- a/examples/Ex020_Rounding_Corners_with_Fillets.py
+++ b/examples/Ex020_Rounding_Corners_with_Fillets.py
@@ -1,4 +1,5 @@
 import cadquery as cq
+from cadquerywrapper import CadQueryWrapper
 
 # Create a plate with 4 rounded corners in the Z-axis.
 # 1.  Establishes a workplane that an object can be built on.
@@ -11,3 +12,10 @@ result = cq.Workplane("XY").box(3, 3, 0.5).edges("|Z").fillet(0.125)
 
 # Displays the result of this script
 show_object(result)
+
+# Validate and export with CadQueryWrapper
+wrapper = CadQueryWrapper(
+    "cadquerywrapper/rules/bambu_printability_rules.json",
+    result,
+)
+wrapper.export_stl("Ex020_Rounding_Corners_with_Fillets.stl")

--- a/examples/Ex021_Splitting_an_Object.py
+++ b/examples/Ex021_Splitting_an_Object.py
@@ -1,4 +1,5 @@
 import cadquery as cq
+from cadquerywrapper import CadQueryWrapper
 
 # Create a simple block with a hole through it that we can split.
 # 1.  Establishes a workplane that an object can be built on.
@@ -22,3 +23,10 @@ result = c.faces(">Y").workplane(-0.5).split(keepTop=True)
 
 # Displays the result of this script
 show_object(result)
+
+# Validate and export with CadQueryWrapper
+wrapper = CadQueryWrapper(
+    "cadquerywrapper/rules/bambu_printability_rules.json",
+    result,
+)
+wrapper.export_stl("Ex021_Splitting_an_Object.stl")

--- a/examples/Ex022_Revolution.py
+++ b/examples/Ex022_Revolution.py
@@ -1,4 +1,5 @@
 import cadquery as cq
+from cadquerywrapper import CadQueryWrapper
 
 # The dimensions of the model. These can be modified rather than changing the
 # shape's code directly.
@@ -19,3 +20,10 @@ result = cq.Workplane("XY").rect(rectangle_width, rectangle_length, False).revol
 
 # Displays the result of this script
 show_object(result)
+
+# Validate and export with CadQueryWrapper
+wrapper = CadQueryWrapper(
+    "cadquerywrapper/rules/bambu_printability_rules.json",
+    result,
+)
+wrapper.export_stl("Ex022_Revolution.stl")

--- a/examples/Ex023_Sweep.py
+++ b/examples/Ex023_Sweep.py
@@ -1,4 +1,5 @@
 import cadquery as cq
+from cadquerywrapper import CadQueryWrapper
 
 # Points we will use to create spline and polyline paths to sweep over
 pts = [(0, 1), (1, 2), (2, 4)]
@@ -34,3 +35,10 @@ show_object(frenetShell.translate((5, 0, 0)))
 show_object(defaultRect.translate((10, 0, 0)))
 show_object(plineSweep)
 show_object(arcSweep.translate((20, 0, 0)))
+
+# Validate and export one of the sweeps
+wrapper = CadQueryWrapper(
+    "cadquerywrapper/rules/bambu_printability_rules.json",
+    defaultSweep,
+)
+wrapper.export_stl("Ex023_Sweep_default.stl")

--- a/examples/Ex024_Sweep_With_Multiple_Sections.py
+++ b/examples/Ex024_Sweep_With_Multiple_Sections.py
@@ -1,4 +1,5 @@
 import cadquery as cq
+from cadquerywrapper import CadQueryWrapper
 
 # X axis line length 20.0
 path = cq.Workplane("XZ").moveTo(-10, 0).lineTo(10, 0)
@@ -86,3 +87,10 @@ show_object(circletorectSweep.translate((0, 5, 0)))
 show_object(recttocircleSweep.translate((0, 10, 0)))
 show_object(specialSweep.translate((0, 15, 0)))
 show_object(arcSweep.translate((0, -5, 0)))
+
+# Validate and export one of the sweeps
+wrapper = CadQueryWrapper(
+    "cadquerywrapper/rules/bambu_printability_rules.json",
+    defaultSweep,
+)
+wrapper.export_stl("Ex024_Sweep_With_Multiple_Sections.stl")

--- a/examples/Ex025_Swept_Helix.py
+++ b/examples/Ex025_Swept_Helix.py
@@ -1,4 +1,5 @@
 import cadquery as cq
+from cadquerywrapper import CadQueryWrapper
 
 r = 0.5  # Radius of the helix
 p = 0.4  # Pitch of the helix - vertical distance between loops
@@ -18,3 +19,10 @@ result = (
 )
 
 show_object(result)
+
+# Validate and export with CadQueryWrapper
+wrapper = CadQueryWrapper(
+    "cadquerywrapper/rules/bambu_printability_rules.json",
+    result,
+)
+wrapper.export_stl("Ex025_Swept_Helix.stl")

--- a/examples/Ex026_Case_Seam_Lip.py
+++ b/examples/Ex026_Case_Seam_Lip.py
@@ -1,4 +1,5 @@
 import cadquery as cq
+from cadquerywrapper import CadQueryWrapper
 from cadquery.selectors import AreaNthSelector
 
 case_bottom = (
@@ -45,3 +46,10 @@ case_top = (
 
 show_object(case_bottom)
 show_object(case_top, options={"alpha": 0.5})
+
+# Validate and export the bottom case
+wrapper = CadQueryWrapper(
+    "cadquerywrapper/rules/bambu_printability_rules.json",
+    case_bottom,
+)
+wrapper.export_stl("Ex026_Case_Bottom.stl")

--- a/examples/Ex100_Lego_Brick.py
+++ b/examples/Ex100_Lego_Brick.py
@@ -1,5 +1,6 @@
 # This script can create any regular rectangular Lego(TM) Brick
 import cadquery as cq
+from cadquerywrapper import CadQueryWrapper
 
 #####
 # Inputs
@@ -68,3 +69,10 @@ else:
 
 # Render the solid
 show_object(tmp)
+
+# Validate and export the final brick
+wrapper = CadQueryWrapper(
+    "cadquerywrapper/rules/bambu_printability_rules.json",
+    tmp,
+)
+wrapper.export_stl("Ex100_Lego_Brick.stl")

--- a/examples/Ex101_InterpPlate.py
+++ b/examples/Ex101_InterpPlate.py
@@ -1,5 +1,6 @@
 from math import sin, cos, pi, sqrt
 import cadquery as cq
+from cadquerywrapper import CadQueryWrapper
 
 # TEST_1
 # example from PythonOCC core_geometry_geomplate.py, use of thickness = 0 returns 2D surface.
@@ -10,6 +11,13 @@ plate_0 = cq.Workplane("XY").interpPlate(edge_points, surface_points, thickness)
 print("plate_0.val().Volume() = ", plate_0.val().Volume())
 plate_0 = plate_0.translate((0, 6 * 12, 0))
 show_object(plate_0)
+
+# Validate and export the first plate
+wrapper = CadQueryWrapper(
+    "cadquerywrapper/rules/bambu_printability_rules.json",
+    plate_0,
+)
+wrapper.export_stl("Ex101_plate_0.stl")
 
 # EXAMPLE 1
 # Plate with 5 sides and 2 bumps, one side is not co-planar with the other sides


### PR DESCRIPTION
## Summary
- demonstrate CadQueryWrapper usage in the example scripts

## Testing
- `pytest --cov=src --cov-report=term --cov-report=xml`
- `ruff check src/ tests/`
- `mypy src/` *(fails: path not found)*
- `black --check src/` *(fails: path not found)*

------
https://chatgpt.com/codex/tasks/task_e_688a4c83a4488329ae919e63fe2d5d05