### PR TITLE
feat: add wrapper example

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,9 @@ except ValidationError as exc:
 wrapper.export_stl("out.stl")
 ```
 
+See `examples/Ex001_Simple_Block.py` for a complete script that validates and
+saves a simple block model using ``CadQueryWrapper``.
+
 ## Code Style
 See [CODE_STYLE.md](CODE_STYLE.md) for contribution guidelines. Monkey patching is prohibited.
 

--- a/examples/Ex001_Simple_Block.py
+++ b/examples/Ex001_Simple_Block.py
@@ -1,4 +1,5 @@
 import cadquery as cq
+from cadquerywrapper import CadQueryWrapper, ValidationError
 
 # These can be modified rather than hardcoding values for each dimension.
 length = 80.0  # Length of the block
@@ -10,6 +11,19 @@ thickness = 10.0  # Thickness of the block
 # 1a. Uses the X and Y origins to define the workplane, meaning that the
 # positive Z direction is "up", and the negative Z direction is "down".
 result = cq.Workplane("XY").box(length, height, thickness)
+
+# Attach a simple model so validation has data to work with
+CadQueryWrapper.attach_model(result, {"minimum_wall_thickness_mm": thickness})
+
+# Wrap the workplane with validation and saving helpers
+wrapper = CadQueryWrapper("cadquerywrapper/rules/bambu_printability_rules.json", result)
+
+try:
+    wrapper.validate()
+except ValidationError as exc:
+    print("Model invalid:", exc)
+
+wrapper.export_stl("simple_block.stl")
 
 # The following method is now outdated, but can still be used to display the
 # results of the script if you want


### PR DESCRIPTION
## Summary
- demonstrate `cadquerywrapper` usage in `Ex001_Simple_Block.py`
- reference the example from the README

## Testing
- `pytest -q`
- `ruff check cadquerywrapper tests | head`
- `mypy cadquerywrapper tests | tail -n 5`

------
https://chatgpt.com/codex/tasks/task_e_688a4c83a4488329ae919e63fe2d5d05