### PR TITLE
Add example runner script

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,16 @@ For running the test suite use the development requirements instead:
 pip install -r requirements-dev.txt
 ```
 
+## Running the Examples
+
+Launch the interactive menu to run any example script:
+
+```bash
+python scripts/run_examples.py
+```
+
+Select a number from the list to execute that example.
+
 ## Usage
 
 ```python

--- a/cadquerywrapper/project.py
+++ b/cadquerywrapper/project.py
@@ -3,14 +3,13 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Any
 
-from .logger import get_logger
-
-logger = get_logger(__name__)
-
 import cadquery as cq
 
 from .save_validator import SaveValidator
-from .validator import ValidationError, Validator
+from .validator import Validator
+from .logger import get_logger
+
+logger = get_logger(__name__)
 
 
 class CadQueryWrapper:

--- a/cadquerywrapper/save_validator.py
+++ b/cadquerywrapper/save_validator.py
@@ -3,13 +3,8 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Any
 
-from .logger import get_logger
-
-logger = get_logger(__name__)
-
-import trimesh
-
 import cadquery as cq
+import trimesh
 
 from .validator import (
     ValidationError,
@@ -19,6 +14,9 @@ from .validator import (
     shape_has_open_edges,
     validate,
 )
+from .logger import get_logger
+
+logger = get_logger(__name__)
 
 
 class SaveValidator:

--- a/cadquerywrapper/validator.py
+++ b/cadquerywrapper/validator.py
@@ -1,7 +1,6 @@
 """Printability rules validation helpers."""
 
 import json
-import logging
 from pathlib import Path
 
 from .logger import get_logger

--- a/scripts/run_examples.py
+++ b/scripts/run_examples.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python3
+"""Interactive menu for running example scripts."""
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+
+EXAMPLES_DIR = Path(__file__).resolve().parents[1] / "examples"
+
+
+def list_examples() -> list[Path]:
+    return sorted(p for p in EXAMPLES_DIR.iterdir() if p.suffix == ".py")
+
+
+def choose_example(examples: list[Path]) -> Path | None:
+    for idx, ex in enumerate(examples, 1):
+        print(f"{idx}. {ex.name}")
+    print("0. Exit")
+    choice = input("Select an example: ")
+    if choice == "0":
+        return None
+    try:
+        idx = int(choice) - 1
+    except ValueError:
+        return None
+    if 0 <= idx < len(examples):
+        return examples[idx]
+    return None
+
+
+def run_example(example: Path) -> None:
+    print(f"\nRunning {example.name}\n{'-' * (8 + len(example.name))}")
+    subprocess.run([sys.executable, str(example)], check=True)
+
+
+def main() -> None:
+    examples = list_examples()
+    if not examples:
+        print("No examples found.")
+        return
+    while True:
+        selection = choose_example(examples)
+        if selection is None:
+            break
+        run_example(selection)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_validator.py
+++ b/tests/test_validator.py
@@ -1,4 +1,3 @@
-import importlib
 import sys
 import types
 from pathlib import Path
@@ -165,9 +164,9 @@ class OverhangShape(DummyShape):
 sys.modules.setdefault("cadquery", _dummy_cq)
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
-from cadquerywrapper.validator import Validator, load_rules, validate
-from cadquerywrapper.save_validator import SaveValidator, ValidationError
-from cadquerywrapper.project import CadQueryWrapper
+from cadquerywrapper.validator import Validator, load_rules, validate  # noqa: E402
+from cadquerywrapper.save_validator import SaveValidator, ValidationError  # noqa: E402
+from cadquerywrapper.project import CadQueryWrapper  # noqa: E402
 
 
 RULES_PATH = Path("cadquerywrapper/rules/bambu_printability_rules.json")


### PR DESCRIPTION
## Summary
- introduce `scripts/run_examples.py` to choose and run example scripts
- document new helper in README
- fix ruff E402 warnings

## Testing
- `ruff check cadquerywrapper tests`
- `mypy cadquerywrapper`
- `black --check cadquerywrapper tests scripts`
- `pytest --cov=cadquerywrapper --cov-report=term --cov-report=xml`

------
https://chatgpt.com/codex/tasks/task_e_688a5085d924832989811ebe61679800